### PR TITLE
PHP 7.3 compat: don't use continue in switch

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -99,13 +99,13 @@ class Path
             switch ($ele) {
                 case '.':
                 case '':
-                    continue;
+                    break;
                 case '..':
                     $cur--;
                     if ($cur < 1) {
                         $cur = 1;
                     }
-                    continue;
+                    break;
                 default:
                     $ret[$cur++] = $ele;
             }


### PR DESCRIPTION
Replace `continue` with `break` in switch statement. This is what `continue` in `switch` does anyway. `continue 2` would have the same effect because there is nothing else in the loop, so it was a coin toss to decide between that and `break`. Fixes issue #1.